### PR TITLE
Connect submarine landing point to many cities

### DIFF
--- a/code/ConvertToStandardPath_MergeSubmarineWithLandCable.py
+++ b/code/ConvertToStandardPath_MergeSubmarineWithLandCable.py
@@ -91,32 +91,22 @@ def get_all_submarine_to_standard_paths_pairs(db_file):
 
 def map_landing_point_to_physical_nodes(landing_point_coords, phys_nodes_coords) -> dict[tuple, list[tuple]]:
     print("\tMapping landing point cities to nearby physical nodes...")
+    DISTANCE_THRESHOLD_KM = 160
     city_mapping = {}
     for landing_point_lati, landing_point_longti, landing_point_city, landing_point_state, landing_point_country in landing_point_coords:
         landing_point_coord = (landing_point_lati, landing_point_longti)
-        min_distance = float('inf')
-        best_city = None
-        best_state = None
-        best_country = None
-        best_coord = None
         for phys_nodes_lati, phys_nodes_longti, phys_nodes_city, phys_nodes_state, phys_nodes_country in phys_nodes_coords:
             phys_nodes_coord = (phys_nodes_lati, phys_nodes_longti)
             if not isinstance(phys_nodes_coord[0], float):
                 continue
-            currdistance = haversine(landing_point_coord, phys_nodes_coord)
-            if (currdistance < min_distance):
-                best_city = phys_nodes_city
-                min_distance = currdistance
-                best_state = phys_nodes_state
-                best_country = phys_nodes_country
-                best_coord = phys_nodes_coord
+            distance_km = haversine(landing_point_coord, phys_nodes_coord)
+            if distance_km > DISTANCE_THRESHOLD_KM:
+                print(
+                    f"warning for city {landing_point_city}, {landing_point_country} and {phys_nodes_city}, {phys_nodes_country} with distance {distance_km}", file=sys.stderr)
+                continue
 
-        if (min_distance > 160):
-            print(
-                f"warning for city {landing_point_city}, {landing_point_country} and {best_city}, {best_country} with distance {min_distance}", file=sys.stderr)
-        else:
             landing_point = (landing_point_city, landing_point_state, landing_point_country, landing_point_coord)
-            physical_node = (best_city, best_state, best_country, best_coord, min_distance)
+            physical_node = (phys_nodes_city, phys_nodes_state, phys_nodes_country, phys_nodes_coord, distance_km)
             city_mapping.get(landing_point, []).append(physical_node)
     return city_mapping
 

--- a/code/ConvertToStandardPath_SubmarineCable.py
+++ b/code/ConvertToStandardPath_SubmarineCable.py
@@ -343,7 +343,7 @@ def insert_submarine_standard_paths_to_database(db_file, submarine_standard_path
     conn.close()
 
 
-def get_all_submarine_standard_paths(db_file):
+def get_all_submarine_standard_paths(db_file: str) -> list[tuple]:
     conn = sqlite3.connect(db_file)
     cursor = conn.cursor()
     sql_query = """

--- a/code/Processing_CloudRegions.py
+++ b/code/Processing_CloudRegions.py
@@ -38,10 +38,6 @@ def find_closest_paths(lat: float, lon: float, db_path: str, max_distance: float
 def cut(line, distance, add_p):
     # Cuts a line in two at a distance from its starting point
     # This is taken from shapely manual
-    # if distance <= 0:
-    #     return [LineString(), LineString(line)]
-    # elif distance >= line.length:
-    #     return [LineString(line), LineString()]
     if distance <= 0.0 or distance >= line.length:
         print(distance, line, line.length, add_p, file=sys.stderr)
         return [LineString(line)]

--- a/code/Processing_CloudRegions.py
+++ b/code/Processing_CloudRegions.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 from collections import defaultdict
 from geopy.distance import geodesic
-from math import inf
+from math import inf, isclose
 from shapely import wkt, shortest_line, LineString, Point
 from sqlite3 import Row as sqlite_Row
 
@@ -36,11 +36,13 @@ def find_closest_paths(lat: float, lon: float, db_path: str, max_distance: float
 # Taken from stackoverflow
 # https://stackoverflow.com/questions/39425093/break-a-shapely-linestring-at-multiple-points
 def cut(line, distance, add_p):
-    # Cuts a line in two at a distance from its starting point
-    # This is taken from shapely manual
-    if distance <= 0.0 or distance >= line.length:
-        print(distance, line, line.length, add_p, file=sys.stderr)
+    """Cuts a line in two at a distance from its starting point."""
+    if isclose(distance, 0.0) or isclose(distance, line.length):
         return [LineString(line)]
+    elif distance < 0.0 or distance > line.length:
+        raise ValueError(f"Distance out of range! {distance} {line.length} {line} {add_p}")
+
+    # This is taken from shapely manual
     coords = list(line.coords)
     for i, p in enumerate(coords):
         pd = line.project(Point(p))

--- a/code/Processing_CloudRegions.py
+++ b/code/Processing_CloudRegions.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 from collections import defaultdict
 from geopy.distance import geodesic
-from math import inf, isclose
+from math import isclose, isnan, nan
 from shapely import wkt, shortest_line, LineString, Point
 from sqlite3 import Row as sqlite_Row
 
@@ -35,12 +35,16 @@ def find_closest_paths(lat: float, lon: float, db_path: str, max_distance: float
 
 # Taken from stackoverflow
 # https://stackoverflow.com/questions/39425093/break-a-shapely-linestring-at-multiple-points
-def cut(line, distance, add_p):
-    """Cuts a line in two at a distance from its starting point."""
+def cut_linestring(line, distance: float = nan, point: Point = None) -> list[LineString]:
+    """Cuts a linestring in two, either at a distance from its starting point, or at a location closest to the given point."""
+    assert not (isnan(distance) and point is None), "Either distance or point must be given"
+    if isnan(distance):
+        distance = line.project(point)
+
     if isclose(distance, 0.0) or isclose(distance, line.length):
         return [LineString(line)]
     elif distance < 0.0 or distance > line.length:
-        raise ValueError(f"Distance out of range! {distance} {line.length} {line} {add_p}")
+        raise ValueError(f"Distance out of range! {distance} {line.length} {line} {point}")
 
     # This is taken from shapely manual
     coords = list(line.coords)
@@ -53,8 +57,8 @@ def cut(line, distance, add_p):
         if pd > distance:
             cp = line.interpolate(distance)
             return [
-                LineString(coords[:i] + [(cp.x, cp.y)] + [(add_p.x, add_p.y)]),
-                LineString([(add_p.x, add_p.y)] + [(cp.x, cp.y)] + coords[i:])]
+                LineString(coords[:i] + [(cp.x, cp.y)] + [(point.x, point.y)]),
+                LineString([(point.x, point.y)] + [(cp.x, cp.y)] + coords[i:])]
 
 
 def distance_of_linestring(ls: LineString) -> float:
@@ -104,8 +108,7 @@ def add_cloud_regions_to_standard_paths(db_path: str,
 
         for row in rows.itertuples(index=False):
             linestring: LineString = wkt.loads(row[7])
-            distance: float = linestring.project(Point(lon, lat))
-            splitted = cut(linestring, distance, Point(lon, lat))
+            splitted = cut_linestring(linestring, point=Point(lon, lat))
             if len(splitted) < 2:
                 continue
             (l1, l2) = splitted


### PR DESCRIPTION
If we just connect each landing point of submarine cables to the closest city in the land paths graph, then some cities may not be properly connected and thus will take a longer detour using land fibers, instead of using the shorter submarine cable.