### PR TITLE
Account for extra segment distance when inserting a new point along a path.

### DIFF
--- a/code/Common.py
+++ b/code/Common.py
@@ -36,3 +36,7 @@ def are_coordinates_close(coordinate1: Coordinate, coordinate2: Coordinate,
         return haversine(coordinate1, coordinate2) < max_distance_km
     else:
         return math.isclose(coordinate1[0], coordinate2[0]) and math.isclose(coordinate1[1], coordinate2[1])
+
+def flip_coordinate(coordinate: Coordinate) -> Coordinate:
+    """Flip the coordinate from (lat, lon) to (lon, lat), or vice versa."""
+    return (coordinate[1], coordinate[0])


### PR DESCRIPTION
When adding Point of Presence (PoP) locations to a shortest path, sometimes the location is not directly on the path, and thus the `cut_linestring` function introduces an extra segment during this node insertion. This fix accounts for the distance difference if this happens.

Relevant portion of the [`cut_linestring` function](https://github.com/c3lab-net/iGDB/blob/9b21d733080e3e5ffc782612d74ff0f7b5f8fa8a/code/Processing_CloudRegions.py#L64):
```Python
            return [
                LineString(coords[:i] + [(cp.x, cp.y)] + [(to_add.x, to_add.y)]),
                LineString([(to_add.x, to_add.y)] + [(cp.x, cp.y)] + coords[i:])]
```

`[(cp.x, cp.y)] + [(to_add.x, to_add.y)]` and `[(to_add.x, to_add.y)] + [(cp.x, cp.y)]` are the extra segments being added, and the caller previously doesn't account for the distance of this additional segment, or recalculate the total distance based on the new linestrings.